### PR TITLE
Change value of 'main' property to 'lib/pwgen_module'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 #pwgen
 A command line implementation of pwgen using Node.js.
 
+## Use as library
+
+```js
+var Pwgen = require('pwgen')
+var pwgen = new Pwgen()
+
+pwgen.includeCapitalLetter = true
+pwgen.includeNumber = true
+pwgen.maxLength = 20
+
+console.log(pwgen.generate())
+```
+
 ##License
 Copyright (C) 2013 Karl Herrick, http://karlherrick.com
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
 	"author": "Karl Herrick",
-	"name": "pwgen",
+	"name": "@jhenning/pwgen",
 	"description": "A command line implementation of pwgen using Node.js.",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"repository": {
 		"type" : "git",
 		"url": "https://github.com/kherrick/pwgen"
 	},
-	"main": "./lib/main.js",
+	"main": "./lib/pwgen_module.js",
 	"bin": {
 		"pwgen": "./bin/pwgen"
 	},


### PR DESCRIPTION
This allows this module to be used as a library while still allowing commandline usage.
